### PR TITLE
Use statuses to check if tests have passed instead of comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This action let non collaborators review
 and merge code without having more then read access to the project.
 
 1. A pull request get submitted
-2. Jenkins runs the tests, comments "Test PASSed."
+2. Jenkins runs the tests and creates a status for the ref, indicating whether tests passed or not
 3. The pull request can be merged by commenting "merge, my change is covered by tests"
 
 ## Installation


### PR DESCRIPTION
We allow merging if ALL checks have passed. This avoid having to
hardcode a specific user (which is making the comments) and hardcoding
a specific comment string to look for.

Of course this requires that Jenkins updates the relevant PR status
and has permissions to do so (Write).